### PR TITLE
Update scorer Dockerfile to use requirements

### DIFF
--- a/services/scorer/Dockerfile
+++ b/services/scorer/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.12-slim
 WORKDIR /app
 COPY requirements.txt ./requirements.txt
-RUN pip install --no-cache-dir openai>=1.14.0 faiss-cpu
+RUN pip install --no-cache-dir -r requirements.txt
 COPY services/scorer/main.py ./main.py
 COPY knowledge ./knowledge
 CMD ["python", "main.py"]


### PR DESCRIPTION
## Summary
- install packages via `pip install --no-cache-dir -r requirements.txt` in `services/scorer/Dockerfile`

## Testing
- `ruff check`
- `pytest -q` *(fails: command not found)*
- `terraform fmt -check` *(fails: command not found)*
- `terraform validate` *(fails: command not found)*
- `docker build -f services/scorer/Dockerfile -t scorer-test .` *(fails: command not found)*
