### PR TITLE
Switch RDS instance to provisioned

### DIFF
--- a/infra/rds.tf
+++ b/infra/rds.tf
@@ -27,6 +27,6 @@ resource "aws_rds_cluster" "eoi_app" {
 resource "aws_rds_cluster_instance" "eoi_app" {
   identifier         = "eoi-app-0"
   cluster_identifier = aws_rds_cluster.eoi_app.id
-  instance_class     = "db.serverless"
+  instance_class     = "db.t3.medium"
   engine             = aws_rds_cluster.eoi_app.engine
 }


### PR DESCRIPTION
## Summary
- use a t3.medium instance class for the RDS cluster instance

## Testing
- `ruff check`
- `pytest` *(fails: command not found)*
- `terraform fmt` *(fails: command not found)*
- `terraform validate` *(fails: command not found)*
