### PR TITLE
Remove unused log export variable

### DIFF
--- a/infra/logs.tf
+++ b/infra/logs.tf
@@ -1,8 +1,3 @@
-variable "log_export_bucket" {
-  description = "Bucket for CloudWatch log exports"
-  type        = string
-}
-
 resource "aws_cloudwatch_log_group" "eoi_scorer" {
   name              = "/ecs/eoi-scorer"
   retention_in_days = 90


### PR DESCRIPTION
## Summary
- drop `log_export_bucket` variable from CloudWatch log groups since it was unused

## Testing
- `ruff check`
- `pytest -q` *(fails: command not found)*
- `terraform fmt -check` *(fails: command not found)*
- `terraform validate` *(fails: command not found)*