### PR TITLE
Implement scorer loop and tests

### DIFF
--- a/services/scorer/main.py
+++ b/services/scorer/main.py
@@ -1,9 +1,13 @@
 import json
+import logging
 import os
 
 import boto3
 import openai
 import sqlalchemy as sa
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 DATABASE_URL = os.getenv('DATABASE_URL', 'sqlite:///eoi.db')
 QUEUE_URL = os.environ['SQS_QUEUE_URL']
@@ -28,20 +32,59 @@ def load_agenda() -> str:
         return f.read()
 
 
-def handle() -> None:
-    msgs = sqs.receive_message(QueueUrl=QUEUE_URL, MaxNumberOfMessages=1)
-    if 'Messages' not in msgs:
-        return
-    msg = msgs['Messages'][0]
+def process_message(msg: dict) -> None:
     body = json.loads(msg['Body'])
-    with engine.connect() as conn:
-        row = conn.execute(sa.text('SELECT data FROM eoi_raw WHERE id=:id'), {'id': body['id']}).mappings().first()
+    try:
+        with engine.connect() as conn:
+            row = conn.execute(
+                sa.text('SELECT data FROM eoi_raw WHERE id=:id'),
+                {'id': body['id']},
+            ).mappings().first()
+    except Exception as exc:  # pragma: no cover - logging only
+        logger.exception('Database read failed: %s', exc)
+        return
+
+    if not row:
+        logger.error('No entry for id %s', body['id'])
+        return
+
     agenda = load_agenda()
     prompt = f"Agenda:\n{agenda}\n\nEntry:\n{row['data']}"
-    resp = openai.ChatCompletion.create(model='openai/o3', messages=[{'role': 'user', 'content': prompt}])
-    with engine.begin() as conn:
-        conn.execute(triage.insert().values(data=resp['choices'][0]['message']['content']))
+
+    try:
+        resp = openai.ChatCompletion.create(
+            model='openai/o3',
+            messages=[{'role': 'user', 'content': prompt}],
+        )
+    except Exception as exc:  # pragma: no cover - logging only
+        logger.exception('OpenAI request failed: %s', exc)
+        return
+
+    try:
+        with engine.begin() as conn:
+            conn.execute(
+                triage.insert().values(
+                    data=resp['choices'][0]['message']['content'],
+                )
+            )
+    except Exception as exc:  # pragma: no cover - logging only
+        logger.exception('Database write failed: %s', exc)
+        return
+
     sqs.delete_message(QueueUrl=QUEUE_URL, ReceiptHandle=msg['ReceiptHandle'])
+
+
+def handle() -> None:
+    while True:
+        msgs = sqs.receive_message(
+            QueueUrl=QUEUE_URL,
+            MaxNumberOfMessages=1,
+            WaitTimeSeconds=20,
+        )
+        if 'Messages' not in msgs:
+            continue
+        for msg in msgs['Messages']:
+            process_message(msg)
 
 
 if __name__ == '__main__':

--- a/tests/test_scorer_main.py
+++ b/tests/test_scorer_main.py
@@ -1,0 +1,64 @@
+import json
+import types
+
+import sqlalchemy as sa
+
+import services.scorer.main as scorer
+
+
+def test_handle_processes_message(monkeypatch):
+    messages = [
+        {
+            'Body': json.dumps({'id': 1}),
+            'ReceiptHandle': 'r1',
+        }
+    ]
+
+    class DummySQS:
+        def __init__(self):
+            self.calls = 0
+            self.deleted = False
+
+        def receive_message(self, **kwargs):
+            assert kwargs.get('WaitTimeSeconds') == 20
+            self.calls += 1
+            if self.calls == 1:
+                return {'Messages': messages}
+            raise KeyboardInterrupt()
+
+        def delete_message(self, QueueUrl, ReceiptHandle):
+            self.deleted = True
+            assert ReceiptHandle == 'r1'
+
+    dummy_sqs = DummySQS()
+    monkeypatch.setattr(scorer, 'sqs', dummy_sqs)
+
+    def dummy_create(**_):
+        return {'choices': [{'message': {'content': 'ok'}}]}
+
+    monkeypatch.setattr(scorer.openai, 'ChatCompletion', types.SimpleNamespace(create=dummy_create))
+    monkeypatch.setattr(scorer, 'load_agenda', lambda: 'agenda')
+
+    engine = sa.create_engine('sqlite://')
+    scorer.engine = engine
+    scorer.metadata.create_all(engine)
+    eoi_raw = sa.Table(
+        'eoi_raw',
+        sa.MetaData(),
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('data', sa.JSON),
+    )
+    eoi_raw.create(engine)
+    with engine.begin() as conn:
+        conn.execute(eoi_raw.insert().values(id=1, data={'foo': 'bar'}))
+
+    try:
+        scorer.handle()
+    except KeyboardInterrupt:
+        pass
+
+    with engine.connect() as conn:
+        row = conn.execute(sa.select(scorer.triage)).mappings().first()
+
+    assert dummy_sqs.deleted
+    assert row['data'] == 'ok'


### PR DESCRIPTION
## Summary
- improve scorer service to poll SQS in a loop
- long poll with `WaitTimeSeconds` and handle missing messages
- add basic error handling and logging
- test scorer message processing

## Testing
- `ruff check`
- `python -m pytest -q` *(fails: No module named pytest)*
- `terraform fmt -check infra` *(fails: terraform not found)*
- `terraform validate infra` *(fails: terraform not found)*