### PR TITLE
Add unit tests for agenda embedder and scoring service

### DIFF
--- a/tests/test_embed_agenda.py
+++ b/tests/test_embed_agenda.py
@@ -1,0 +1,44 @@
+from click.testing import CliRunner
+
+import scripts.embed_agenda as embed_agenda
+
+
+def test_embed_agenda_creates_index(tmp_path, monkeypatch):
+    agenda_path = tmp_path / 'agenda.md'
+    agenda_path.write_text('one\n\n two')
+
+    def dummy_create(*, input, model):
+        assert input == ['one', 'two']
+        return {'data': [{'embedding': [1.0, 0.0]}, {'embedding': [0.0, 1.0]}]}
+
+    monkeypatch.setattr(embed_agenda.openai.Embedding, 'create', dummy_create)
+
+    added = []
+
+    class DummyIndex:
+        def __init__(self, d):
+            self.d = d
+
+        def add(self, vecs):
+            added.extend(vecs.tolist())
+
+    index_inst = DummyIndex(2)
+    monkeypatch.setattr(embed_agenda.faiss, 'IndexFlatL2', lambda d: index_inst)
+
+    written = {}
+
+    def dummy_write_index(index, path):
+        written['index'] = index
+        written['path'] = path
+
+    monkeypatch.setattr(embed_agenda.faiss, 'write_index', dummy_write_index)
+
+    runner = CliRunner()
+    out_path = tmp_path / 'index.faiss'
+    result = runner.invoke(
+        embed_agenda.main, ['--agenda', str(agenda_path), '--output', str(out_path)]
+    )
+    assert result.exit_code == 0
+    assert index_inst.d == 2
+    assert added == [[1.0, 0.0], [0.0, 1.0]]
+    assert written == {'index': index_inst, 'path': str(out_path)}

--- a/tests/test_scorer.py
+++ b/tests/test_scorer.py
@@ -1,0 +1,82 @@
+import json
+from datetime import datetime
+from importlib import reload
+
+import boto3
+import openai
+import sqlalchemy as sa
+
+
+def test_handle_processes_message(tmp_path, monkeypatch):
+    agenda_path = tmp_path / 'agenda.md'
+    agenda_path.write_text('my agenda')
+
+    monkeypatch.setenv('AGENDAS_PATH', str(agenda_path))
+    monkeypatch.setenv('DATABASE_URL', f'sqlite:///{tmp_path}/db.sqlite')
+    monkeypatch.setenv('SQS_QUEUE_URL', 'qurl')
+    monkeypatch.setenv('OPENAI_API_KEY', 'secret-id')
+
+    class DummySQS:
+        def __init__(self):
+            self.deleted = False
+
+        def receive_message(self, **kwargs):
+            return {
+                'Messages': [
+                    {'Body': json.dumps({'id': 1}), 'ReceiptHandle': 'rh'}
+                ]
+            }
+
+        def delete_message(self, **kwargs):
+            self.deleted = True
+
+    class DummySecrets:
+        def get_secret_value(self, SecretId):
+            return {'SecretString': 'openai-key'}
+
+    dummy_sqs = DummySQS()
+
+    def client(service, *args, **kwargs):
+        if service == 'sqs':
+            return dummy_sqs
+        if service == 'secretsmanager':
+            return DummySecrets()
+        raise ValueError(service)
+
+    monkeypatch.setattr(boto3, 'client', client)
+
+    class DummyChat:
+        @staticmethod
+        def create(*args, **kwargs):
+            return {'choices': [{'message': {'content': 'ok'}}]}
+
+    monkeypatch.setattr(openai, 'ChatCompletion', DummyChat)
+
+    import services.scorer.main as mod
+    reload(mod)
+
+    meta = sa.MetaData()
+    eoi_raw = sa.Table(
+        'eoi_raw',
+        meta,
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('submitted_at', sa.DateTime),
+        sa.Column('data', sa.JSON),
+    )
+    meta.create_all(mod.engine)
+
+    with mod.engine.begin() as conn:
+        conn.execute(
+            eoi_raw.insert().values(
+                id=1,
+                submitted_at=datetime.utcnow(),
+                data={'foo': 'bar'},
+            )
+        )
+
+    mod.handle()
+
+    with mod.engine.connect() as conn:
+        row = conn.execute(mod.triage.select()).mappings().first()
+    assert row['data'] == 'ok'
+    assert dummy_sqs.deleted


### PR DESCRIPTION
## Summary
- add unit tests for agenda embedding script
- create mocked tests for scorer service

## Testing
- `ruff check`
- `python -m pytest -q` *(fails: No module named pytest)*
- `terraform fmt -check` *(fails: command not found)*
- `terraform validate` *(fails: command not found)*