### PR TITLE
Add release tarball script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,9 @@ test:
 	.venv/bin/pytest
 
 lint:
-	.venv/bin/ruff check
-	terraform fmt -check infra
-	terraform validate infra
+        .venv/bin/ruff check
+        terraform fmt -check infra
+        terraform validate infra
+
+release:
+	scripts/create_release_tarball.sh

--- a/README.md
+++ b/README.md
@@ -9,3 +9,11 @@ make init
 make plan
 python scripts/csv_loader.py --file sample.csv
 ```
+
+## Release tarball
+
+Create a compressed archive of the project without the `.git` directory:
+
+```bash
+make release
+```

--- a/scripts/create_release_tarball.sh
+++ b/scripts/create_release_tarball.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Determine repository root
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+TARBALL="${1:-eoi-grant.tar.gz}"
+
+# Create the tarball excluding the .git directory
+cd "$REPO_ROOT"
+
+tar --exclude=.git -czf "$TARBALL" .
+
+echo "Created $TARBALL"


### PR DESCRIPTION
## Summary
- add helper script to create release tarballs
- call the script from a new `make release` target
- document how to create a release archive

## Testing
- `ruff check`
- `pytest` *(fails: command not found)*
- `terraform fmt -check infra` *(fails: command not found)*
- `terraform validate infra` *(fails: command not found)*