### PR TITLE
Add Fargate config and CI plan check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,3 +20,8 @@ jobs:
       - run: .venv/bin/pytest
       - run: terraform fmt -check infra
       - run: terraform validate infra
+      - run: terraform plan -input=false infra
+        env:
+          TF_VAR_scorer_image: dummy
+          TF_VAR_openai_api_key_secret_id: dummy
+          TF_VAR_database_url: dummy

--- a/infra/ecs.tf
+++ b/infra/ecs.tf
@@ -1,5 +1,12 @@
 resource "aws_ecs_cluster" "main" {
   name = "eoi-cluster"
+
+  capacity_providers = ["FARGATE", "FARGATE_SPOT"]
+
+  default_capacity_provider_strategy {
+    capacity_provider = "FARGATE"
+    weight            = 1
+  }
 }
 
 resource "aws_ecs_task_definition" "scorer" {
@@ -17,9 +24,11 @@ resource "aws_ecs_task_definition" "scorer" {
       image     = var.scorer_image
       essential = true
       environment = [
-        { name = "SQS_QUEUE_URL", value = aws_sqs_queue.ingest.url },
-        { name = "OPENAI_API_KEY", value = var.openai_api_key_secret_id },
-        { name = "DATABASE_URL", value = var.database_url }
+        { name = "SQS_QUEUE_URL", value = aws_sqs_queue.ingest.url }
+      ]
+      secrets = [
+        { name = "OPENAI_API_KEY", valueFrom = var.openai_api_key_secret_id },
+        { name = "DATABASE_URL", valueFrom = var.database_url }
       ]
       logConfiguration = {
         logDriver = "awslogs"

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -6,7 +6,7 @@ variable "scorer_image" {
 variable "scorer_schedule" {
   description = "Cron or rate expression for running the scorer"
   type        = string
-  default     = "rate(5 minutes)"
+  default     = "rate(2 minutes)"
 }
 
 variable "openai_api_key_secret_id" {


### PR DESCRIPTION
## Summary
- wire ECS cluster to use both Fargate capacity providers
- inject secrets into the scorer task definition
- run the scorer every 2 minutes
- exercise `terraform plan` in CI

## Testing
- `ruff check`
- `pytest` *(fails: command not found)*
- `terraform fmt -check` *(fails: command not found)*
- `terraform validate` *(fails: command not found)*