### PR TITLE
Add portal API stub and frontend

### DIFF
--- a/portal/index.html
+++ b/portal/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Portal</title>
+    <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
+    <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="text/javascript">
+      const e = React.createElement;
+      function App() {
+        return e('button', { onClick: () => navigator.clipboard.writeText('') }, 'Copy');
+      }
+      ReactDOM.createRoot(document.getElementById('root')).render(e(App));
+    </script>
+  </body>
+</html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,5 @@ openai>=1.14.0
 faiss-cpu
 pytest
 ruff
+fastapi
+uvicorn

--- a/services/portal-api/Dockerfile
+++ b/services/portal-api/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.12-slim
+WORKDIR /app
+COPY requirements.txt ./requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+COPY services/portal-api/main.py ./main.py
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/services/portal-api/main.py
+++ b/services/portal-api/main.py
@@ -1,0 +1,23 @@
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+
+app = FastAPI()
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"] ,
+    allow_headers=["*"],
+)
+
+@app.get("/drafts/{draft_id}")
+async def read_draft(draft_id: int) -> dict[str, int]:
+    """Return a stub draft payload."""
+    return {"id": draft_id}
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(app, host="0.0.0.0", port=8000)


### PR DESCRIPTION
## Summary
- add FastAPI service in `services/portal-api`
- allow any-host CORS and implement `/drafts/{id}` stub
- add Dockerfile for portal API service
- create skeleton React page with a Copy button
- include FastAPI and uvicorn in requirements

## Testing
- `ruff check`
- `python -m pytest -q` *(fails: No module named pytest)*
- `terraform fmt -check infra` *(fails: terraform not found)*
- `terraform validate infra` *(fails: terraform not found)*