### PR TITLE
Update ECS scorer resources

### DIFF
--- a/infra/ecs.tf
+++ b/infra/ecs.tf
@@ -11,8 +11,8 @@ resource "aws_ecs_cluster" "main" {
 
 resource "aws_ecs_task_definition" "scorer" {
   family                   = "eoi-scorer"
-  cpu                      = "512"
-  memory                   = "1024"
+  cpu                      = "256"
+  memory                   = "512"
   network_mode             = "awsvpc"
   requires_compatibilities = ["FARGATE"]
   execution_role_arn       = aws_iam_role.task_execution.arn


### PR DESCRIPTION
## Summary
- reduce ECS scorer task to 256 CPU and 512 MiB memory

## Testing
- `ruff check`
- `python -m pytest -q` *(fails: No module named pytest)*
- `terraform fmt -check infra` *(fails: command not found)*
- `terraform validate infra` *(fails: command not found)*