### PR TITLE
Add upload CSV lambda

### DIFF
--- a/scripts/upload_csv_lambda.py
+++ b/scripts/upload_csv_lambda.py
@@ -1,0 +1,19 @@
+import base64
+import io
+import json
+
+import pandas as pd
+
+import scripts.csv_loader as csv_loader
+
+
+def lambda_handler(event, context):
+    """Receive a CSV payload and pass it to ``csv_loader``."""
+    body = event.get("body", "")
+    if event.get("isBase64Encoded"):
+        body = base64.b64decode(body).decode("utf-8")
+
+    df = pd.read_csv(io.StringIO(body), parse_dates=["submitted_at"], dayfirst=True)
+    csv_loader.load_dataframe(df)
+    return {"statusCode": 200, "body": json.dumps({"status": "ok"})}
+

--- a/tests/test_upload_csv_lambda.py
+++ b/tests/test_upload_csv_lambda.py
@@ -1,0 +1,27 @@
+import base64
+
+import pandas as pd
+
+import scripts.upload_csv_lambda as upl
+import scripts.csv_loader as csv_loader
+
+
+def test_lambda_handler(monkeypatch):
+    captured = {}
+
+    def dummy_load_dataframe(df: pd.DataFrame) -> None:
+        captured['df'] = df
+
+    monkeypatch.setattr(csv_loader, 'load_dataframe', dummy_load_dataframe)
+
+    csv_bytes = b'submitted_at,name\n01/01/24 10:00:00,Tester\n'
+    event = {
+        'body': base64.b64encode(csv_bytes).decode('utf-8'),
+        'isBase64Encoded': True,
+    }
+
+    resp = upl.lambda_handler(event, None)
+
+    assert resp['statusCode'] == 200
+    assert 'df' in captured
+    assert list(captured['df']['name']) == ['Tester']


### PR DESCRIPTION
## Summary
- add AWS Lambda to accept CSV uploads
- support reusing csv loader to load from in-memory dataframe
- test upload_csv_lambda

## Testing
- `ruff check`
- `python -m pytest -q` *(fails: No module named pytest)*
- `terraform fmt -check infra` *(fails: terraform not found)*
- `terraform validate infra` *(fails: terraform not found)*
