### PR TITLE
Add portal service CRUD and React site

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,8 @@ Create a compressed archive of the project without the `.git` directory:
 ```bash
 make release
 ```
+
+## Portal
+
+The `portal` directory contains a small React application. Build artifacts can be
+uploaded to the S3 bucket defined by `portal_bucket_name` for static hosting.

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -14,3 +14,7 @@ output "db_endpoint" {
 output "ecs_cluster_arn" {
   value = aws_ecs_cluster.main.arn
 }
+
+output "portal_url" {
+  value = aws_s3_bucket_website_configuration.portal.website_endpoint
+}

--- a/infra/s3.tf
+++ b/infra/s3.tf
@@ -1,0 +1,45 @@
+variable "portal_bucket_name" {
+  description = "Name for the portal static site bucket"
+  type        = string
+}
+
+resource "aws_s3_bucket" "portal" {
+  bucket        = var.portal_bucket_name
+  force_destroy = true
+}
+
+resource "aws_s3_bucket_public_access_block" "portal" {
+  bucket                  = aws_s3_bucket.portal.id
+  block_public_acls       = false
+  block_public_policy     = false
+  ignore_public_acls      = false
+  restrict_public_buckets = false
+}
+
+resource "aws_s3_bucket_website_configuration" "portal" {
+  bucket = aws_s3_bucket.portal.id
+
+  index_document {
+    suffix = "index.html"
+  }
+
+  error_document {
+    key = "index.html"
+  }
+}
+
+data "aws_iam_policy_document" "portal_policy" {
+  statement {
+    actions   = ["s3:GetObject"]
+    resources = ["${aws_s3_bucket.portal.arn}/*"]
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "portal" {
+  bucket = aws_s3_bucket.portal.id
+  policy = data.aws_iam_policy_document.portal_policy.json
+}

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -18,3 +18,8 @@ variable "database_url" {
   description = "Database connection string for the scorer"
   type        = string
 }
+
+variable "portal_bucket_name" {
+  description = "Name for the portal static site bucket"
+  type        = string
+}

--- a/portal/app.js
+++ b/portal/app.js
@@ -1,0 +1,26 @@
+const e = React.createElement;
+
+function App() {
+  const [draft, setDraft] = React.useState('');
+  const [copy, setCopy] = React.useState('');
+  const [saved, setSaved] = React.useState(null);
+
+  async function save() {
+    const resp = await fetch('/api/drafts', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ draft, copy }),
+    });
+    const data = await resp.json();
+    setSaved(data.id);
+  }
+
+  return e('div', null,
+    e('textarea', { value: draft, onChange: (ev) => setDraft(ev.target.value) }),
+    e('textarea', { value: copy, onChange: (ev) => setCopy(ev.target.value) }),
+    e('button', { onClick: save }, 'Save'),
+    saved && e('div', null, `Saved as ${saved}`),
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('root')).render(e(App));

--- a/portal/index.html
+++ b/portal/index.html
@@ -3,17 +3,11 @@
   <head>
     <meta charset="UTF-8" />
     <title>Portal</title>
-    <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
-    <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+    <script crossorigin src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
+    <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
   </head>
   <body>
     <div id="root"></div>
-    <script type="text/javascript">
-      const e = React.createElement;
-      function App() {
-        return e('button', { onClick: () => navigator.clipboard.writeText('') }, 'Copy');
-      }
-      ReactDOM.createRoot(document.getElementById('root')).render(e(App));
-    </script>
+    <script src="app.js"></script>
   </body>
 </html>

--- a/services/portal-api/Dockerfile
+++ b/services/portal-api/Dockerfile
@@ -2,5 +2,5 @@ FROM python:3.12-slim
 WORKDIR /app
 COPY requirements.txt ./requirements.txt
 RUN pip install --no-cache-dir -r requirements.txt
-COPY services/portal-api/main.py ./main.py
+COPY services/portal-api/ ./
 CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/services/portal-api/main.py
+++ b/services/portal-api/main.py
@@ -1,5 +1,32 @@
-from fastapi import FastAPI
+import os
+
+import sqlalchemy as sa
+from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel
+
+DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///portal.db")
+engine = sa.create_engine(DATABASE_URL)
+metadata = sa.MetaData()
+
+Drafts = sa.Table(
+    "drafts",
+    metadata,
+    sa.Column("id", sa.Integer, primary_key=True, autoincrement=True),
+    sa.Column("draft", sa.Text, nullable=False),
+    sa.Column("copy", sa.Text),
+)
+metadata.create_all(engine)
+
+
+class DraftCreate(BaseModel):
+    draft: str
+    copy: str | None = None
+
+
+class Draft(DraftCreate):
+    id: int
+
 
 app = FastAPI()
 
@@ -7,17 +34,59 @@ app.add_middleware(
     CORSMiddleware,
     allow_origins=["*"],
     allow_credentials=True,
-    allow_methods=["*"] ,
+    allow_methods=["*"],
     allow_headers=["*"],
 )
 
-@app.get("/drafts/{draft_id}")
-async def read_draft(draft_id: int) -> dict[str, int]:
-    """Return a stub draft payload."""
-    return {"id": draft_id}
+
+@app.post("/drafts", response_model=Draft)
+async def create_draft(payload: DraftCreate) -> Draft:
+    """Create a new draft entry."""
+    with engine.begin() as conn:
+        result = conn.execute(
+            Drafts.insert().values(draft=payload.draft, copy=payload.copy)
+        )
+        pk = result.inserted_primary_key[0]
+        row = conn.execute(sa.select(Drafts).where(Drafts.c.id == pk)).mappings().first()
+    return Draft(**row)
 
 
-if __name__ == "__main__":
+@app.get("/drafts/{draft_id}", response_model=Draft)
+async def read_draft(draft_id: int) -> Draft:
+    """Return a stored draft."""
+    with engine.connect() as conn:
+        row = conn.execute(sa.select(Drafts).where(Drafts.c.id == draft_id)).mappings().first()
+    if not row:
+        raise HTTPException(status_code=404, detail="Draft not found")
+    return Draft(**row)
+
+
+@app.put("/drafts/{draft_id}", response_model=Draft)
+async def update_draft(draft_id: int, payload: DraftCreate) -> Draft:
+    """Update an existing draft."""
+    with engine.begin() as conn:
+        result = conn.execute(
+            Drafts.update()
+            .where(Drafts.c.id == draft_id)
+            .values(draft=payload.draft, copy=payload.copy)
+        )
+        if result.rowcount == 0:
+            raise HTTPException(status_code=404, detail="Draft not found")
+        row = conn.execute(sa.select(Drafts).where(Drafts.c.id == draft_id)).mappings().first()
+    return Draft(**row)
+
+
+@app.delete("/drafts/{draft_id}")
+async def delete_draft(draft_id: int) -> dict[str, bool]:
+    """Delete a draft."""
+    with engine.begin() as conn:
+        result = conn.execute(Drafts.delete().where(Drafts.c.id == draft_id))
+        if result.rowcount == 0:
+            raise HTTPException(status_code=404, detail="Draft not found")
+    return {"ok": True}
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
     import uvicorn
 
     uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/tests/test_portal_api.py
+++ b/tests/test_portal_api.py
@@ -1,0 +1,34 @@
+import importlib
+
+from fastapi.testclient import TestClient
+
+
+def get_app(tmp_path, monkeypatch):
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{tmp_path}/db.sqlite")
+    module = importlib.import_module("services.portal_api.main")
+    importlib.reload(module)
+    return module.app
+
+
+def test_crud_lifecycle(tmp_path, monkeypatch):
+    app = get_app(tmp_path, monkeypatch)
+    client = TestClient(app)
+
+    resp = client.post("/drafts", json={"draft": "a", "copy": "b"})
+    assert resp.status_code == 200
+    created = resp.json()
+    assert created["draft"] == "a"
+    draft_id = created["id"]
+
+    resp = client.get(f"/drafts/{draft_id}")
+    assert resp.status_code == 200
+
+    resp = client.put(f"/drafts/{draft_id}", json={"draft": "c", "copy": "d"})
+    assert resp.status_code == 200
+    updated = resp.json()
+    assert updated["draft"] == "c"
+
+    resp = client.delete(f"/drafts/{draft_id}")
+    assert resp.status_code == 200
+    resp = client.get(f"/drafts/{draft_id}")
+    assert resp.status_code == 404


### PR DESCRIPTION
## Summary
- add a FastAPI CRUD implementation for drafts
- update Dockerfile to copy service source
- ship a minimal React portal
- expose S3 static site infrastructure
- test portal API with FastAPI TestClient

## Testing
- `ruff check`
- `python -m pytest -q` *(fails: No module named pytest)*
- `terraform fmt -check infra` *(fails: terraform not found)*
- `terraform validate infra` *(fails: terraform not found)*