### PR TITLE
Fix log export bucket variable

### DIFF
--- a/infra/logs.tf
+++ b/infra/logs.tf
@@ -7,3 +7,9 @@ resource "aws_cloudwatch_log_group" "email_draft" {
   name              = "/ecs/email-draft"
   retention_in_days = 90
 }
+
+# Bucket for exporting CloudWatch logs
+resource "aws_s3_bucket" "log_export" {
+  bucket        = var.log_export_bucket
+  force_destroy = true
+}

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -23,3 +23,8 @@ variable "portal_bucket_name" {
   description = "Name for the portal static site bucket"
   type        = string
 }
+
+variable "log_export_bucket" {
+  description = "S3 bucket name for exporting CloudWatch logs"
+  type        = string
+}


### PR DESCRIPTION
## Summary
- add `log_export_bucket` variable definition
- create log export bucket resource

## Testing
- `ruff check`
- `pytest -q` *(fails: command not found)*
- `terraform fmt -check` *(fails: command not found)*
- `terraform validate` *(fails: command not found)*