### PR TITLE
Fix Aurora Serverless cluster

### DIFF
--- a/infra/rds.tf
+++ b/infra/rds.tf
@@ -24,9 +24,3 @@ resource "aws_rds_cluster" "eoi_app" {
   }
 }
 
-resource "aws_rds_cluster_instance" "eoi_app" {
-  identifier         = "eoi-app-0"
-  cluster_identifier = aws_rds_cluster.eoi_app.id
-  instance_class     = "db.t3.medium"
-  engine             = aws_rds_cluster.eoi_app.engine
-}


### PR DESCRIPTION
## Summary
- remove `aws_rds_cluster_instance` from RDS configuration

## Testing
- `ruff check`
- `python -m pytest -q` *(fails: No module named pytest)*
- `terraform fmt -check` *(fails: terraform not installed)*
- `terraform validate` *(fails: terraform not installed)*