### PR TITLE
Fix scorer to use secret ID env var

### DIFF
--- a/infra/ecs.tf
+++ b/infra/ecs.tf
@@ -24,10 +24,10 @@ resource "aws_ecs_task_definition" "scorer" {
       image     = var.scorer_image
       essential = true
       environment = [
-        { name = "SQS_QUEUE_URL", value = aws_sqs_queue.ingest.url }
+        { name = "SQS_QUEUE_URL", value = aws_sqs_queue.ingest.url },
+        { name = "OPENAI_SECRET_ID", value = var.openai_api_key_secret_id }
       ]
       secrets = [
-        { name = "OPENAI_API_KEY", valueFrom = var.openai_api_key_secret_id },
         { name = "DATABASE_URL", valueFrom = var.database_url }
       ]
       logConfiguration = {

--- a/services/scorer/main.py
+++ b/services/scorer/main.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import os
+import getpass
 
 import boto3
 import openai
@@ -14,7 +15,9 @@ QUEUE_URL = os.environ['SQS_QUEUE_URL']
 AGENDAS_PATH = os.getenv('AGENDAS_PATH', 'knowledge/research_agenda.md')
 
 secrets = boto3.client('secretsmanager')
-openai.api_key = secrets.get_secret_value(SecretId=os.environ['OPENAI_API_KEY'])['SecretString']
+default_secret_id = f"users/{getpass.getuser()}/openai_api_key"
+secret_id = os.getenv('OPENAI_SECRET_ID', default_secret_id)
+openai.api_key = secrets.get_secret_value(SecretId=secret_id)['SecretString']
 
 sqs = boto3.client('sqs')
 engine = sa.create_engine(DATABASE_URL)

--- a/tests/test_scorer.py
+++ b/tests/test_scorer.py
@@ -14,7 +14,7 @@ def test_handle_processes_message(tmp_path, monkeypatch):
     monkeypatch.setenv('AGENDAS_PATH', str(agenda_path))
     monkeypatch.setenv('DATABASE_URL', f'sqlite:///{tmp_path}/db.sqlite')
     monkeypatch.setenv('SQS_QUEUE_URL', 'qurl')
-    monkeypatch.setenv('OPENAI_API_KEY', 'secret-id')
+    monkeypatch.setenv('OPENAI_SECRET_ID', 'secret-id')
 
     class DummySQS:
         def __init__(self):


### PR DESCRIPTION
## Summary
- make the scorer's secret ID configurable via `OPENAI_SECRET_ID`
- update ECS task definition to pass the secret name
- adjust tests for new variable

## Testing
- `ruff check`
- `python -m pytest -q` *(fails: No module named pytest)*
- `terraform fmt -check` *(fails: terraform not found)*
- `terraform validate` *(fails: terraform not found)*