### PR TITLE
Add CSV upload API

### DIFF
--- a/tests/test_portal_api.py
+++ b/tests/test_portal_api.py
@@ -5,6 +5,7 @@ from fastapi.testclient import TestClient
 
 def get_app(tmp_path, monkeypatch):
     monkeypatch.setenv("DATABASE_URL", f"sqlite:///{tmp_path}/db.sqlite")
+    monkeypatch.setenv("UPLOAD_DIR", str(tmp_path / "uploads"))
     module = importlib.import_module("services.portal_api.main")
     importlib.reload(module)
     return module.app
@@ -32,3 +33,29 @@ def test_crud_lifecycle(tmp_path, monkeypatch):
     assert resp.status_code == 200
     resp = client.get(f"/drafts/{draft_id}")
     assert resp.status_code == 404
+
+
+def test_upload_endpoint(tmp_path, monkeypatch):
+    captured = {}
+
+    def dummy_load_dataframe(df):
+        captured["rows"] = list(df["name"])
+
+    monkeypatch.setattr(
+        importlib.import_module("scripts.csv_loader"),
+        "load_dataframe",
+        dummy_load_dataframe,
+    )
+
+    app = get_app(tmp_path, monkeypatch)
+    client = TestClient(app)
+
+    csv_content = "submitted_at,name\n01/01/24 10:00:00,Tester\n"
+    resp = client.post(
+        "/upload",
+        files={"file": ("data.csv", csv_content, "text/csv")},
+    )
+    assert resp.status_code == 200
+    assert captured.get("rows") == ["Tester"]
+    upload_path = tmp_path / "uploads" / "data.csv"
+    assert upload_path.exists()


### PR DESCRIPTION
## Summary
- add `/upload` endpoint to store uploaded CSV files and run the loader
- store uploads in a configurable directory
- test that uploads work and trigger the loader

## Testing
- `ruff check`
- `python -m pytest -q` *(fails: No module named pytest)*
- `terraform fmt -check` *(fails: command not found)*
- `terraform validate` *(fails: command not found)*